### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "jquery": "~2.1.3",
     "angular-ui-select2": "~0.0.5",
     "select2": "~3.4.8",
-    "angular-ui-bootstrap": "~0.12.0",
+    "angular-ui-bootstrap": "0.12.0",
     "es5-shim": "~2.0.11",
     "json3": "~3.3.2",
     "leaflet": "~0.7.3",


### PR DESCRIPTION
you need to point exactly this version of ui-bootstrap because of hard-coded somewhere link to 12.0